### PR TITLE
LM-5769 fix aws lambda resource creation modules to have min provider version 3.41.0

### DIFF
--- a/modules/aws-alb-to-cloudwatch-lambda/requirements.tf
+++ b/modules/aws-alb-to-cloudwatch-lambda/requirements.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = ">= 3.43"
+      version = ">= 3.41"
     }
   }
 }


### PR DESCRIPTION
LM-5769 fix aws lambda resource creation modules to have min provider version 3.41.0