### PR TITLE
DMVP-411 mongodb atlas fix

### DIFF
--- a/modules/mongodb-atlas/README.md
+++ b/modules/mongodb-atlas/README.md
@@ -12,7 +12,30 @@ module "mongodb-atlas" {
 
   project_name = "your project name goes here"
 
-  users = ["user1", "user2", "userN"]
+  users = [
+        {
+          username = "user1"
+          roles = {
+            database_name = "admin"
+            role_name     = "readWriteAnyDatabase"
+          }
+          scopes = {
+            name = "test-development"
+            type = "CLUSTER"
+          }
+        },
+        {
+          username = "user2"
+          roles = {
+            database_name = "database"
+            role_name     = "readWrite"
+          }
+          scopes = {
+            name = "cluster"
+            type = "CLUSTER"
+          }
+        }
+      ]
   ip_addresses = ["ip1", "ip2", "ip3", "ipN"]
 
   access_users = [
@@ -38,6 +61,7 @@ mongodbatlas_cloud_provider_snapshot_backup_policy resource requires access thro
    (to do so you can also add your current IP address as a source one).
 
 ## Tips
-1. To turn some policy_items off in mongodbatlas_cloud_backup_schedule, you need to pass "" to retention_unit. For example, if var.policy_item_hourly.retention_unit = "" then policy_item_hourly is not created.
-2. mongodbatlas_cloud_provider_snapshot_backup_policy resource is deprecated but if there is a need to use it, make use_cloud_provider_snapshot_backup_policy true.
-3. There is a problem in MongoDB provider with invitations for users. You can make them by this module, but it'll be better to delete mongodbatlas_org_invitation and mongodbatlas_project_invitation resources from the state.
+1. You need to pass "" to `retention_unit` to turn some `policy_items` off in `mongodbatlas_cloud_backup_schedule`. For example, if var.policy_item_hourly.retention_unit = "" then `policy_item_hourly` is not created.
+2. `mongodbatlas_cloud_provider_snapshot_backup_policy` resource is deprecated but if there is a need to use it, make `use_cloud_provider_snapshot_backup_policy` true.
+3. There is a problem in MongoDB provider with invitations for users. You can make them by this module, but it'll be better to delete `mongodbatlas_org_invitation` and `mongodbatlas_project_invitation` resources from the state.
+4. You need to pass the role and scope blocks for each user to create them. Just pass a list of objects to the `users` variable.

--- a/modules/mongodb-atlas/outputs.tf
+++ b/modules/mongodb-atlas/outputs.tf
@@ -1,11 +1,11 @@
-output cluster_connection_string {
+output "cluster_connection_string" {
   value       = mongodbatlas_cluster.main.connection_strings[0].standard
   sensitive   = false
   description = "Mongodb connecton string"
 }
 
-output "users" {
-  value = {
-    for k, p in mongodbatlas_database_user.user :  p.username => nonsensitive(random_password.password[k].result)
-  }
-}
+# output "users" {
+#   value = {
+#     for k, p in mongodbatlas_database_user.user :  p.username => nonsensitive(random_password.password[k].result)
+#   }
+# }

--- a/modules/mongodb-atlas/project.tf
+++ b/modules/mongodb-atlas/project.tf
@@ -7,8 +7,8 @@ resource "mongodbatlas_project" "main" {
     for_each = { for team in var.teams : team.team_id => team }
 
     content {
-      team_id    = each.value.team_id
-      role_names = each.value.role_names
+      team_id    = teams.value.team_id
+      role_names = teams.value.role_names
     }
   }
 }

--- a/modules/mongodb-atlas/project.tf
+++ b/modules/mongodb-atlas/project.tf
@@ -3,8 +3,12 @@ resource "mongodbatlas_project" "main" {
   org_id                       = var.org_id
   with_default_alerts_settings = var.with_default_alerts_settings
 
-  teams {
-    role_names = var.team_roles
-    team_id    = var.team_id
+  dynamic "teams" {
+    for_each = { for team in var.teams : team.team_id => team }
+
+    content {
+      team_id    = each.value.team_id
+      role_names = each.value.role_names
+    }
   }
 }

--- a/modules/mongodb-atlas/requirements.tf
+++ b/modules/mongodb-atlas/requirements.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     mongodbatlas = {
-      source = "mongodb/mongodbatlas"
-      version = "1.1.1"
+      source  = "mongodb/mongodbatlas"
+      version = "1.2.0"
     }
   }
 }

--- a/modules/mongodb-atlas/variables.tf
+++ b/modules/mongodb-atlas/variables.tf
@@ -163,18 +163,6 @@ variable "org_invitation_enabled" {
   description = "Allows to controll wheather the invitation for organization will be created"
 }
 
-variable "team_roles" {
-  type        = list(string)
-  default     = null
-  description = "Project roles assigned to the team."
-}
-
-variable "team_id" {
-  type        = string
-  default     = null
-  description = "The unique identifier of the team which will be associated with the project."
-}
-
 variable "policy_item_hourly" {
   default = {
     frequency_interval = 6
@@ -230,14 +218,6 @@ variable "with_default_alerts_settings" {
   type        = bool
   default     = true
   description = "It allows users to disable the creation of the default alert settings."
-}
-
-variable "teams" {
-  default = {
-    team_id    = null
-    role_names = null
-  }
-  description = "team_id - The unique identifier of the team you want to associate with the project. role_names - Each string in the array represents a project role you want to assign to the team. Every user associated with the team inherits these roles."
 }
 
 variable "create_alert_configuration" {
@@ -363,4 +343,13 @@ variable "schedule_restore_window_days" {
   type        = number
   default     = 1
   description = "Number of days back in time you can restore to with point-in-time accuracy."
+}
+
+variable "teams" {
+  type = list(object({
+    team_id    = string
+    role_names = list(string)
+  }))
+  default = [
+  ]
 }


### PR DESCRIPTION
## Why?
There can be more than one teams in a project. 

## How?
We've made teams block dynamic to be able to make teams with a list.