### PR TITLE
Optional parameters SNS related parameters for route53-alerts-notify

### DIFF
--- a/modules/route53-alerts-notify/README.md
+++ b/modules/route53-alerts-notify/README.md
@@ -87,9 +87,9 @@ module "healthcheck" {
 | <a name="input_regions"></a> [regions](#input\_regions) | (Optional) A list of AWS regions that you want Amazon Route 53 health checkers to check the specified endpoint from. | `list(string)` | <pre>[<br>  "us-east-1",<br>  "eu-west-1",<br>  "ap-northeast-1"<br>]</pre> | no |
 | <a name="input_request_interval"></a> [request\_interval](#input\_request\_interval) | The number of seconds between the time that Amazon Route 53 gets a response from your endpoint and the time that it sends the next health-check request. | `string` | `"30"` | no |
 | <a name="input_resource_path"></a> [resource\_path](#input\_resource\_path) | Path name coming after fqdn. | `string` | `""` | no |
-| <a name="input_slack_channel"></a> [slack\_channel](#input\_slack\_channel) | Slack Channel | `string` | n/a | yes |
-| <a name="input_slack_hook_url"></a> [slack\_hook\_url](#input\_slack\_hook\_url) | This is slack webhook url path without domain | `string` | n/a | yes |
-| <a name="input_slack_username"></a> [slack\_username](#input\_slack\_username) | Slack User Name | `string` | n/a | yes |
+| <a name="input_slack_channel"></a> [slack\_channel](#input\_slack\_channel) | Slack Channel | `string` | `null` | no |
+| <a name="input_slack_hook_url"></a> [slack\_hook\_url](#input\_slack\_hook\_url) | This is slack webhook url path without domain | `string` | `null` | no |
+| <a name="input_slack_username"></a> [slack\_username](#input\_slack\_username) | Slack User Name | `string` | `null` | no |
 | <a name="input_sms_message_body"></a> [sms\_message\_body](#input\_sms\_message\_body) | n/a | `string` | `"sms_message_body"` | no |
 | <a name="input_sns_subscription_email_address_list"></a> [sns\_subscription\_email\_address\_list](#input\_sns\_subscription\_email\_address\_list) | List of email addresses | `list(string)` | `[]` | no |
 | <a name="input_sns_subscription_phone_number_list"></a> [sns\_subscription\_phone\_number\_list](#input\_sns\_subscription\_phone\_number\_list) | List of telephone numbers to subscribe to SNS. | `list(string)` | `[]` | no |

--- a/modules/route53-alerts-notify/README.md
+++ b/modules/route53-alerts-notify/README.md
@@ -93,10 +93,11 @@ module "healthcheck" {
 | <a name="input_sms_message_body"></a> [sms\_message\_body](#input\_sms\_message\_body) | n/a | `string` | `"sms_message_body"` | no |
 | <a name="input_sns_subscription_email_address_list"></a> [sns\_subscription\_email\_address\_list](#input\_sns\_subscription\_email\_address\_list) | List of email addresses | `list(string)` | `[]` | no |
 | <a name="input_sns_subscription_phone_number_list"></a> [sns\_subscription\_phone\_number\_list](#input\_sns\_subscription\_phone\_number\_list) | List of telephone numbers to subscribe to SNS. | `list(string)` | `[]` | no |
+| <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | The ARN of an SNS topic to which notifications will be sent. This does not relate to the other SNS topic variables. | `string` | `null` | no |
 | <a name="input_statistic"></a> [statistic](#input\_statistic) | Statistic. | `string` | `"Minimum"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags object. | `map` | `{}` | no |
 | <a name="input_threshold"></a> [threshold](#input\_threshold) | Threshold. | `string` | `"1"` | no |
-| <a name="input_topic_name"></a> [topic\_name](#input\_topic\_name) | SNS topic name. | `string` | `"topic"` | no |
+| <a name="input_topic_name"></a> [topic\_name](#input\_topic\_name) | SNS base name with which SNS topics in this module will be created. | `string` | `"topic"` | no |
 | <a name="input_treat_missing_data"></a> [treat\_missing\_data](#input\_treat\_missing\_data) | n/a | `string` | `"breaching"` | no |
 | <a name="input_type"></a> [type](#input\_type) | Type of health check. | `string` | `"HTTPS"` | no |
 | <a name="input_unit"></a> [unit](#input\_unit) | n/a | `string` | `"None"` | no |

--- a/modules/route53-alerts-notify/cloudwatch_alarm.tf
+++ b/modules/route53-alerts-notify/cloudwatch_alarm.tf
@@ -1,8 +1,8 @@
 ### SNS slack lambda notification about health checks ###
 
 data "aws_sns_topic" "aws_sns_topic_slack_health_check" {
-
-  name = "${replace("${var.domain_name}${var.resource_path}", "/[./]+/", "-")}-slack"
+  count = local.notify_slack ? 1 : 0
+  name  = "${replace("${var.domain_name}${var.resource_path}", "/[./]+/", "-")}-slack"
   depends_on = [
     module.notify_slack
   ]
@@ -23,13 +23,8 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-down" {
   dimensions = {
     HealthCheckId = aws_route53_health_check.healthcheck.id
   }
-  alarm_description = var.alarm_description_down
-  alarm_actions = [
-    aws_sns_topic.this-email.arn,                           // email
-    aws_sns_topic.this-sms.arn,                             // sms
-    aws_sns_topic.this-opsgenie.arn,                        // Opsgenie
-    data.aws_sns_topic.aws_sns_topic_slack_health_check.arn // slack
-  ]
+  alarm_description         = var.alarm_description_down
+  alarm_actions             = local.alarm_actions
   insufficient_data_actions = []
   treat_missing_data        = var.treat_missing_data #"breaching"
   depends_on = [
@@ -49,13 +44,8 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-up" {
   dimensions = {
     HealthCheckId = aws_route53_health_check.healthcheck.id
   }
-  alarm_description = var.alarm_description_up
-  ok_actions = [
-    aws_sns_topic.this-email.arn,                           // email
-    aws_sns_topic.this-sms.arn,                             // sms
-    aws_sns_topic.this-opsgenie.arn,                        // Opsgenie
-    data.aws_sns_topic.aws_sns_topic_slack_health_check.arn // slack
-  ]
+  alarm_description         = var.alarm_description_up
+  ok_actions                = local.alarm_actions
   insufficient_data_actions = []
   treat_missing_data        = var.treat_missing_data #"breaching"
   depends_on = [

--- a/modules/route53-alerts-notify/lambdas.tf
+++ b/modules/route53-alerts-notify/lambdas.tf
@@ -1,4 +1,5 @@
 module "notify_slack" {
+  count   = local.notify_slack ? 1 : 0
   source  = "terraform-aws-modules/notify-slack/aws"
   version = "4.18.0"
 

--- a/modules/route53-alerts-notify/locals.tf
+++ b/modules/route53-alerts-notify/locals.tf
@@ -7,10 +7,11 @@ locals {
   # multiple topics are optional. We filter the ones not used.
   alarm_actions = [
     for topic in [
-      local.notify_email ? aws_sns_topic.this-email[0].arn : null,                           // email
-      local.notify_sms ? aws_sns_topic.this-sms[0].arn : null,                               // sms
-      local.notify_opsgenie ? aws_sns_topic.this-opsgenie[0].arn : null,                     // Opsgenie
-      local.notify_slack ? data.aws_sns_topic.aws_sns_topic_slack_health_check[0].arn : null // slack
+      local.notify_email ? aws_sns_topic.this-email[0].arn : null,                            // email
+      local.notify_sms ? aws_sns_topic.this-sms[0].arn : null,                                // sms
+      local.notify_opsgenie ? aws_sns_topic.this-opsgenie[0].arn : null,                      // Opsgenie
+      local.notify_slack ? data.aws_sns_topic.aws_sns_topic_slack_health_check[0].arn : null, // slack
+      var.sns_topic_arn                                                                       // custom topic
     ] :
     topic if topic != null
   ]

--- a/modules/route53-alerts-notify/locals.tf
+++ b/modules/route53-alerts-notify/locals.tf
@@ -1,0 +1,17 @@
+locals {
+  notify_slack    = var.slack_hook_url == null ? false : true
+  notify_opsgenie = length(var.opsgenie_endpoint) > 0 ? true : false
+  notify_sms      = length(var.sns_subscription_phone_number_list) > 0 ? true : false
+  notify_email    = length(var.sns_subscription_email_address_list) > 0 ? true : false
+
+  # multiple topics are optional. We filter the ones not used.
+  alarm_actions = [
+    for topic in [
+      local.notify_email ? aws_sns_topic.this-email[0].arn : null,                           // email
+      local.notify_sms ? aws_sns_topic.this-sms[0].arn : null,                               // sms
+      local.notify_opsgenie ? aws_sns_topic.this-opsgenie[0].arn : null,                     // Opsgenie
+      local.notify_slack ? data.aws_sns_topic.aws_sns_topic_slack_health_check[0].arn : null // slack
+    ] :
+    topic if topic != null
+  ]
+}

--- a/modules/route53-alerts-notify/sns_email_topic_subscription.tf
+++ b/modules/route53-alerts-notify/sns_email_topic_subscription.tf
@@ -1,6 +1,7 @@
 # Create sns topic for email notifications (should share same region with provider)
 resource "aws_sns_topic" "this-email" {
-  name = "${replace("${var.domain_name}${var.resource_path}", "/[./]+/", "-")}-email"
+  count = local.notify_email ? 1 : 0
+  name  = "${replace("${var.domain_name}${var.resource_path}", "/[./]+/", "-")}-email"
 
   delivery_policy = <<EOF
 {
@@ -27,7 +28,7 @@ EOF
 # Subscribe sns to email
 resource "aws_sns_topic_subscription" "email" {
   count     = length(var.sns_subscription_email_address_list)
-  topic_arn = aws_sns_topic.this-email.arn
+  topic_arn = aws_sns_topic.this-email[0].arn
   protocol  = "email"
   endpoint  = element(var.sns_subscription_email_address_list, count.index)
 }

--- a/modules/route53-alerts-notify/sns_opesgenie_topic_subscription.tf
+++ b/modules/route53-alerts-notify/sns_opesgenie_topic_subscription.tf
@@ -1,6 +1,7 @@
 # Create sns topic for opsgenie notifications
 resource "aws_sns_topic" "this-opsgenie" {
-  name = "${replace("${var.domain_name}${var.resource_path}", "/[./]+/", "-")}-opsgenie"
+  count = local.notify_opsgenie ? 1 : 0
+  name  = "${replace("${var.domain_name}${var.resource_path}", "/[./]+/", "-")}-opsgenie"
 
   delivery_policy = <<EOF
 {
@@ -26,7 +27,7 @@ EOF
 # Subscribe sns to opsgenie
 resource "aws_sns_topic_subscription" "opsgenie" {
   count     = length(var.opsgenie_endpoint)
-  topic_arn = aws_sns_topic.this-opsgenie.arn
+  topic_arn = aws_sns_topic.this-opsgenie[0].arn
   protocol  = "https"
   endpoint  = element(var.opsgenie_endpoint, count.index)
 }

--- a/modules/route53-alerts-notify/sns_sms_topic_subscription.tf
+++ b/modules/route53-alerts-notify/sns_sms_topic_subscription.tf
@@ -1,6 +1,7 @@
 # Create sns topic for sms notifications
 resource "aws_sns_topic" "this-sms" {
-  name = "${replace(var.domain_name, ".", "-")}-sms"
+  count = local.notify_sms ? 1 : 0
+  name  = "${replace(var.domain_name, ".", "-")}-sms"
 
   delivery_policy = <<EOF
 {
@@ -27,7 +28,7 @@ EOF
 # Subscribe sns to sms
 resource "aws_sns_topic_subscription" "sms" {
   count     = length(var.sns_subscription_phone_number_list)
-  topic_arn = aws_sns_topic.this-sms.arn
+  topic_arn = aws_sns_topic.this-sms[0].arn
   protocol  = "sms"
   endpoint  = element(var.sns_subscription_phone_number_list, count.index)
 }

--- a/modules/route53-alerts-notify/variables.tf
+++ b/modules/route53-alerts-notify/variables.tf
@@ -166,16 +166,19 @@ variable "sms_message_body" {
 variable "slack_hook_url" {
   type        = string
   description = "This is slack webhook url path without domain"
+  default     = null
 }
 
 variable "slack_channel" {
   type        = string
   description = "Slack Channel"
+  default     = null
 }
 
 variable "slack_username" {
   type        = string
   description = "Slack User Name"
+  default     = null
 }
 
 ### Opsgenie variables

--- a/modules/route53-alerts-notify/variables.tf
+++ b/modules/route53-alerts-notify/variables.tf
@@ -139,10 +139,16 @@ variable "depends" {
 
 
 ### SNS Topic related variables
+variable "sns_topic_arn" {
+  type        = string
+  description = "The ARN of an SNS topic to which notifications will be sent. This does not relate to the other SNS topic variables."
+  default     = null
+}
+
 variable "topic_name" {
   type        = string
   default     = "topic"
-  description = "SNS topic name."
+  description = "SNS base name with which SNS topics in this module will be created."
 }
 
 variable "sns_subscription_email_address_list" {


### PR DESCRIPTION
This introduces changes to the existing SNS related input parameters for `route53-alerts-notify`. They all become optional. The topics and the lambda function for slack notifications become optional too. 

Additionally a new parameter is introduced for passing a custom `ARN` for the SNS topic to use. 