### PR TITLE
introduce variable for route53-alerts-notify alert prefixes

### DIFF
--- a/modules/route53-alerts-notify/README.md
+++ b/modules/route53-alerts-notify/README.md
@@ -70,6 +70,8 @@ module "healthcheck" {
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | n/a | `list(string)` | `[]` | no |
 | <a name="input_alarm_description_down"></a> [alarm\_description\_down](#input\_alarm\_description\_down) | n/a | `string` | `"This metric monitors whether the service endpoint is down or not."` | no |
 | <a name="input_alarm_description_up"></a> [alarm\_description\_up](#input\_alarm\_description\_up) | n/a | `string` | `"This metric monitors whether the service endpoint is up"` | no |
+| <a name="input_alarm_prefix_down"></a> [alarm\_prefix\_down](#input\_alarm\_prefix\_down) | A prefix for the alarm message when the host is down. The default is a slack emoji. | `string` | `":x: "` | no |
+| <a name="input_alarm_prefix_up"></a> [alarm\_prefix\_up](#input\_alarm\_prefix\_up) | A prefix for the alarm message when the host is up. The default is a slack emoji. | `string` | `":white_check_mark: "` | no |
 | <a name="input_alarm_region"></a> [alarm\_region](#input\_alarm\_region) | Region from where the alarms must be monitored. All regions are taken if the value is omited. | `string` | `"eu-central-1"` | no |
 | <a name="input_comparison_operator"></a> [comparison\_operator](#input\_comparison\_operator) | Comparison operator. | `string` | `"LessThanThreshold"` | no |
 | <a name="input_depends"></a> [depends](#input\_depends) | n/a | `list` | `[]` | no |

--- a/modules/route53-alerts-notify/cloudwatch_alarm.tf
+++ b/modules/route53-alerts-notify/cloudwatch_alarm.tf
@@ -11,7 +11,7 @@ data "aws_sns_topic" "aws_sns_topic_slack_health_check" {
 
 ### Create a cloudwatch healthcheck metric alarm
 resource "aws_cloudwatch_metric_alarm" "metric-alarm-down" {
-  alarm_name          = ":x: ${var.domain_name}${var.resource_path}"
+  alarm_name          = "${var.alarm_prefix_down}${var.domain_name}${var.resource_path}"
   namespace           = var.namespace
   metric_name         = var.metric_name
   comparison_operator = var.comparison_operator
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-down" {
   ]
 }
 resource "aws_cloudwatch_metric_alarm" "metric-alarm-up" {
-  alarm_name          = ":white_check_mark: ${var.domain_name}${var.resource_path}"
+  alarm_name          = "${var.alarm_prefix_up}${var.domain_name}${var.resource_path}"
   namespace           = var.namespace
   metric_name         = var.metric_name
   comparison_operator = var.comparison_operator

--- a/modules/route53-alerts-notify/variables.tf
+++ b/modules/route53-alerts-notify/variables.tf
@@ -123,6 +123,19 @@ variable "alarm_description_up" {
   type    = string
   default = "This metric monitors whether the service endpoint is up"
 }
+
+variable "alarm_prefix_down" {
+  description = "A prefix for the alarm message when the host is down. The default is a slack emoji."
+  type        = string
+  default     = ":x: "
+}
+
+variable "alarm_prefix_up" {
+  description = "A prefix for the alarm message when the host is up. The default is a slack emoji."
+  type        = string
+  default     = ":white_check_mark: "
+}
+
 variable "alarm_actions" {
   type    = list(string)
   default = []


### PR DESCRIPTION
When not using slack for notifications the default emojis set as prefixes are not suitable. I want to be able to replace them and introduced two variables for them. 