### PR TITLE
Cloudwatch alarm notify settings

### DIFF
--- a/modules/cloudwatch-alarm-notify/README.md
+++ b/modules/cloudwatch-alarm-notify/README.md
@@ -119,6 +119,8 @@ No requirements.
 | <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | n/a | `list(string)` | `[]` | no |
 | <a name="input_alarm_description"></a> [alarm\_description](#input\_alarm\_description) | n/a | `string` | `""` | no |
 | <a name="input_alarm_name"></a> [alarm\_name](#input\_alarm\_name) | Domain name or ip address of checking service. | `string` | n/a | yes |
+| <a name="input_alarm_prefix_down"></a> [alarm\_prefix\_down](#input\_alarm\_prefix\_down) | A prefix for the alarm message when the host is down. The default is a slack emoji. | `string` | `":x: "` | no |
+| <a name="input_alarm_prefix_up"></a> [alarm\_prefix\_up](#input\_alarm\_prefix\_up) | A prefix for the alarm message when the host is up. The default is a slack emoji. | `string` | `":white_check_mark: "` | no |
 | <a name="input_alert_type_name"></a> [alert\_type\_name](#input\_alert\_type\_name) | Alert\_Type | `string` | `"other"` | no |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | Specifies the number of days you want to retain log events in log group for Lambda. | `number` | `0` | no |
 | <a name="input_comparison_operator"></a> [comparison\_operator](#input\_comparison\_operator) | Comparison operator. | `string` | `""` | no |

--- a/modules/cloudwatch-alarm-notify/README.md
+++ b/modules/cloudwatch-alarm-notify/README.md
@@ -137,6 +137,7 @@ No requirements.
 | <a name="input_sms_message_body"></a> [sms\_message\_body](#input\_sms\_message\_body) | n/a | `string` | `"sms_message_body"` | no |
 | <a name="input_sns_subscription_email_address_list"></a> [sns\_subscription\_email\_address\_list](#input\_sns\_subscription\_email\_address\_list) | List of email addresses | `list(string)` | `[]` | no |
 | <a name="input_sns_subscription_phone_number_list"></a> [sns\_subscription\_phone\_number\_list](#input\_sns\_subscription\_phone\_number\_list) | List of telephone numbers to subscribe to SNS. | `list(string)` | `[]` | no |
+| <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | The ARN of an SNS topic to which notifications will be sent. This does not relate to the other SNS topic variables. | `string` | `null` | no |
 | <a name="input_statistic"></a> [statistic](#input\_statistic) | Statistic. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags object. | `map` | `{}` | no |
 | <a name="input_threshold"></a> [threshold](#input\_threshold) | Threshold. | `string` | `""` | no |

--- a/modules/cloudwatch-alarm-notify/main.tf
+++ b/modules/cloudwatch-alarm-notify/main.tf
@@ -47,6 +47,9 @@ locals {
     module.notify_slack.*.this_slack_topic_arn,          // slack
     var.sns_topic_arn == null ? [] : [var.sns_topic_arn] // custom
   )
+  # ensure that there is no % in the tag value. Sometimes you want the name of
+  # the metric to be part of the alarm name. Some metrics have the % sign in the name.
+  tag_name = replace("${var.alarm_name}-alerts", "%", "Percent")
 }
 
 ### Create a cloudwatch healthcheck metric alarm
@@ -89,6 +92,6 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-up" {
   ok_actions                = local.actions
 
   tags = {
-    Name = "${var.alarm_name}-alerts"
+    Name = local.tag_name
   }
 }

--- a/modules/cloudwatch-alarm-notify/main.tf
+++ b/modules/cloudwatch-alarm-notify/main.tf
@@ -41,10 +41,11 @@ locals {
   alarm_description_down         = "This metric monitors ${var.alarm_name} when threshold > ${var.threshold != "" ? var.threshold : lookup(local.default_alert_variables_object, "threshold", "default_threshold")}"
   default_alert_variables_object = lookup(local.default, var.alert_type_name, {})
   actions = concat(
-    aws_sns_topic.k8s-alerts-notify-email.*.arn,    // email
-    aws_sns_topic.k8s-alerts-notify-sms.*.arn,      // sms
-    aws_sns_topic.k8s-alerts-notify-opsgenie.*.arn, // Opsgenie
-    module.notify_slack.*.this_slack_topic_arn      // slack
+    aws_sns_topic.k8s-alerts-notify-email.*.arn,         // email
+    aws_sns_topic.k8s-alerts-notify-sms.*.arn,           // sms
+    aws_sns_topic.k8s-alerts-notify-opsgenie.*.arn,      // Opsgenie
+    module.notify_slack.*.this_slack_topic_arn,          // slack
+    var.sns_topic_arn == null ? [] : [var.sns_topic_arn] // custom
   )
 }
 

--- a/modules/cloudwatch-alarm-notify/main.tf
+++ b/modules/cloudwatch-alarm-notify/main.tf
@@ -50,7 +50,7 @@ locals {
 
 ### Create a cloudwatch healthcheck metric alarm
 resource "aws_cloudwatch_metric_alarm" "metric-alarm-down" {
-  alarm_name                = ":x: ${var.alarm_name}"
+  alarm_name                = "${var.alarm_prefix_down}${var.alarm_name}"
   namespace                 = var.namespace != "" ? var.namespace : lookup(local.default_alert_variables_object, "namespace", "default_namespace")
   metric_name               = var.metric_name != "" ? var.metric_name : lookup(local.default_alert_variables_object, "metric_name", "default_metric_name")
   comparison_operator       = var.comparison_operator != "" ? var.comparison_operator : lookup(local.default_alert_variables_object, "comparison_operator", "default_comparison_operator")
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "metric-alarm-down" {
 
 
 resource "aws_cloudwatch_metric_alarm" "metric-alarm-up" {
-  alarm_name                = ":white_check_mark: ${var.alarm_name}"
+  alarm_name                = "${var.alarm_prefix_down}${var.alarm_name}"
   namespace                 = var.namespace != "" ? var.namespace : lookup(local.default_alert_variables_object, "namespace", "default_namespace")
   metric_name               = var.metric_name != "" ? var.metric_name : lookup(local.default_alert_variables_object, "metric_name", "default_metric_name")
   comparison_operator       = var.comparison_operator != "" ? var.comparison_operator : lookup(local.default_alert_variables_object, "comparison_operator", "default_comparison_operator")

--- a/modules/cloudwatch-alarm-notify/variables.tf
+++ b/modules/cloudwatch-alarm-notify/variables.tf
@@ -98,6 +98,12 @@ variable "alarm_description" {
 }
 
 ### SNS Topic related variables
+variable "sns_topic_arn" {
+  type        = string
+  description = "The ARN of an SNS topic to which notifications will be sent. This does not relate to the other SNS topic variables."
+  default     = null
+}
+
 variable "sns_subscription_email_address_list" {
   type        = list(string)
   default     = []

--- a/modules/cloudwatch-alarm-notify/variables.tf
+++ b/modules/cloudwatch-alarm-notify/variables.tf
@@ -3,6 +3,18 @@ variable "alarm_name" {
   description = "Domain name or ip address of checking service."
 }
 
+variable "alarm_prefix_down" {
+  description = "A prefix for the alarm message when the host is down. The default is a slack emoji."
+  type        = string
+  default     = ":x: "
+}
+
+variable "alarm_prefix_up" {
+  description = "A prefix for the alarm message when the host is up. The default is a slack emoji."
+  type        = string
+  default     = ":white_check_mark: "
+}
+
 variable "tags" {
   # type = object
   default     = {}


### PR DESCRIPTION
Introduce two new features:

- configurable alarm prefixes (for e.g. when slack is not used but MSTeams)
- custom SNS topic arn