### PR TITLE
fix(DMVP-3900): Made waf and cloudtrail alerts insufficient data filled with 0

### DIFF
--- a/modules/cloudtrail/README.md
+++ b/modules/cloudtrail/README.md
@@ -97,7 +97,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alerts"></a> [alerts](#module\_alerts) | dasmeta/monitoring/aws//modules/alerts | 1.3.8 |
+| <a name="module_alerts"></a> [alerts](#module\_alerts) | dasmeta/monitoring/aws//modules/alerts | 1.18.0 |
 | <a name="module_cmdb"></a> [cmdb](#module\_cmdb) | ./modules/cmdb-integration | n/a |
 | <a name="module_log_metric_filter"></a> [log\_metric\_filter](#module\_log\_metric\_filter) | dasmeta/monitoring/aws//modules/cloudwatch-log-based-metrics | 1.3.9 |
 

--- a/modules/cloudtrail/alerts.tf
+++ b/modules/cloudtrail/alerts.tf
@@ -1,6 +1,6 @@
 module "alerts" {
   source  = "dasmeta/monitoring/aws//modules/alerts"
-  version = "1.3.8"
+  version = "1.18.0"
 
   sns_topic = var.alerts.sns_topic_name
   alerts = [
@@ -10,6 +10,7 @@ module "alerts" {
       statistic : "sum"
       filters : {}
       equation : "gte"
+      fill_insufficient_data : true
       threshold : 1
       period : 10
     }

--- a/modules/cloudtrail/role.tf
+++ b/modules/cloudtrail/role.tf
@@ -1,13 +1,13 @@
 resource "aws_iam_role" "cloudtrail_roles" {
   count              = var.enable_cloudwatch_logs ? 1 : 0
-  name               = "CloudTrailToCloudWatchRole"
+  name               = "CloudTrailToCloudWatchRole-${var.name}"
   assume_role_policy = var.cloudtrail_assume_role_policy_document
 }
 
 resource "aws_iam_policy" "cloudtrail_policy" {
   count = var.enable_cloudwatch_logs ? 1 : 0
 
-  name        = "send-cloudtrail-to-cloudwatch"
+  name        = "send-cloudtrail-to-cloudwatch-${var.name}"
   description = "Policy for trail to send events to cloudwatch log groups."
   policy      = <<-EOF
     {

--- a/modules/cloudtrail/tests/alerts-enabled/0-setup.tf
+++ b/modules/cloudtrail/tests/alerts-enabled/0-setup.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
-    test = {
-      source = "terraform.io/builtin/test"
-    }
+    # test = {
+    #   source = "terraform.io/builtin/test"
+    # }
 
     aws = {
       source  = "hashicorp/aws"

--- a/modules/cloudtrail/tests/alerts-enabled/1-example.tf
+++ b/modules/cloudtrail/tests/alerts-enabled/1-example.tf
@@ -1,10 +1,10 @@
 module "this" {
   source = "../../"
 
-  name = "audit-project"
+  name = "audit-project-test"
 
   enable_cloudwatch_logs      = true
-  cloud_watch_logs_group_name = "audit-project-cloudtrail-logs"
+  cloud_watch_logs_group_name = "audit-project-cloudtrail-logs-test"
 
   alerts = {
     events = ["iam-user-creation-or-deletion"]

--- a/modules/cloudtrail/tests/alerts-enabled/2-assert.tf
+++ b/modules/cloudtrail/tests/alerts-enabled/2-assert.tf
@@ -1,9 +1,9 @@
-resource "test_assertions" "dummy" {
-  component = "this"
+# resource "test_assertions" "dummy" {
+#   component = "this"
 
-  equal "scheme" {
-    description = "As module does not have any output and data just make sure the case runs. Probably can be thrown away."
-    got         = "all good"
-    want        = "all good"
-  }
-}
+#   equal "scheme" {
+#     description = "As module does not have any output and data just make sure the case runs. Probably can be thrown away."
+#     got         = "all good"
+#     want        = "all good"
+#   }
+# }

--- a/modules/cloudtrail/tests/alerts-enabled/README.md
+++ b/modules/cloudtrail/tests/alerts-enabled/README.md
@@ -11,9 +11,7 @@
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_test"></a> [test](#provider\_test) | n/a |
+No providers.
 
 ## Modules
 
@@ -23,9 +21,7 @@
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| test_assertions.dummy | resource |
+No resources.
 
 ## Inputs
 

--- a/modules/waf/README.md
+++ b/modules/waf/README.md
@@ -337,7 +337,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_alerts"></a> [alerts](#module\_alerts) | dasmeta/monitoring/aws//modules/alerts | 1.6.0 |
+| <a name="module_alerts"></a> [alerts](#module\_alerts) | dasmeta/monitoring/aws//modules/alerts | 1.17.0 |
 | <a name="module_monitoring_dashboard"></a> [monitoring\_dashboard](#module\_monitoring\_dashboard) | dasmeta/monitoring/aws//modules/dashboard | 1.7.0 |
 | <a name="module_waf"></a> [waf](#module\_waf) | dasmeta/waf-webaclv2/aws | 0.0.1 |
 

--- a/modules/waf/alerts.tf
+++ b/modules/waf/alerts.tf
@@ -1,6 +1,6 @@
 module "alerts" {
   source  = "dasmeta/monitoring/aws//modules/alerts"
-  version = "1.6.0"
+  version = "1.17.0"
 
   count = var.alarms.enabled ? 1 : 0
 
@@ -14,9 +14,10 @@ module "alerts" {
         Rule   = "ALL",
         Region = data.aws_region.current.name
       }
-      period    = try(var.alarms.custom_values.all.period, 60)
-      statistic = try(var.alarms.custom_values.all.statistic, "count")
-      threshold = try(var.alarms.custom_values.all.threshold, 100)
+      period                 = try(var.alarms.custom_values.all.period, 60)
+      statistic              = try(var.alarms.custom_values.all.statistic, "count")
+      threshold              = try(var.alarms.custom_values.all.threshold, 100)
+      fill_insufficient_data = try(var.alarms.custom_values.all.fill_insufficient_data, true)
     },
     {
       name   = "WAF: High Blocks for Known Bad Inputs on ${var.name}"
@@ -26,9 +27,10 @@ module "alerts" {
         Rule   = "AWS-AWSManagedRulesKnownBadInputsRuleSet",
         Region = data.aws_region.current.name
       }
-      period    = try(var.alarms.custom_values.knownbadinputsruleset.period, 60)
-      statistic = try(var.alarms.custom_values.knownbadinputsruleset.statistic, "count")
-      threshold = try(var.alarms.custom_values.knownbadinputsruleset.threshold, 100)
+      period                 = try(var.alarms.custom_values.knownbadinputsruleset.period, 60)
+      statistic              = try(var.alarms.custom_values.knownbadinputsruleset.statistic, "count")
+      threshold              = try(var.alarms.custom_values.knownbadinputsruleset.threshold, 100)
+      fill_insufficient_data = try(var.alarms.custom_values.knownbadinputsruleset.fill_insufficient_data, true)
     },
     {
       name   = "WAF: Increased Blocking Activity for Linux Rules on ${var.name}"
@@ -38,9 +40,10 @@ module "alerts" {
         Rule   = "AWS-AWSManagedRulesLinuxRuleSet",
         Region = data.aws_region.current.name
       }
-      period    = try(var.alarms.custom_values.linuxrulesset.period, 60)
-      statistic = try(var.alarms.custom_values.linuxrulesset.statistic, "count")
-      threshold = try(var.alarms.custom_values.linuxrulesset.threshold, 100)
+      period                 = try(var.alarms.custom_values.linuxrulesset.period, 60)
+      statistic              = try(var.alarms.custom_values.linuxrulesset.statistic, "count")
+      threshold              = try(var.alarms.custom_values.linuxrulesset.threshold, 100)
+      fill_insufficient_data = try(var.alarms.custom_values.linuxrulesset.fill_insufficient_data, true)
     },
     {
       name   = "WAF: High Block Rate for Poor IP Reputation on ${var.name}"
@@ -50,9 +53,10 @@ module "alerts" {
         Rule   = "AWS-AWSManagedRulesAmazonIpReputationList",
         Region = data.aws_region.current.name
       }
-      period    = try(var.alarms.custom_values.ipreputationlist.period, 60)
-      statistic = try(var.alarms.custom_values.ipreputationlist.statistic, "count")
-      threshold = try(var.alarms.custom_values.ipreputationlist.threshold, 100)
+      period                 = try(var.alarms.custom_values.ipreputationlist.period, 60)
+      statistic              = try(var.alarms.custom_values.ipreputationlist.statistic, "count")
+      threshold              = try(var.alarms.custom_values.ipreputationlist.threshold, 100)
+      fill_insufficient_data = try(var.alarms.custom_values.ipreputationlist.fill_insufficient_data, true)
     },
     {
       name   = "WAF: Consistent Blocking Activity for Common Rules on ${var.name}"
@@ -62,9 +66,10 @@ module "alerts" {
         Rule   = "AWS-AWSManagedRulesCommonRuleSet",
         Region = data.aws_region.current.name
       }
-      period    = try(var.alarms.custom_values.commonruleset.period, 60)
-      statistic = try(var.alarms.custom_values.commonruleset.statistic, "count")
-      threshold = try(var.alarms.custom_values.commonruleset.threshold, 100)
+      period                 = try(var.alarms.custom_values.commonruleset.period, 60)
+      statistic              = try(var.alarms.custom_values.commonruleset.statistic, "count")
+      threshold              = try(var.alarms.custom_values.commonruleset.threshold, 100)
+      fill_insufficient_data = try(var.alarms.custom_values.commonruleset.fill_insufficient_data, true)
     },
     {
       name   = "WAF: Elevated Blocking for SQL Injection Attacks on ${var.name}"
@@ -74,9 +79,10 @@ module "alerts" {
         Rule   = "AWS-AWSManagedRulesSQLiRuleSet",
         Region = data.aws_region.current.name
       }
-      period    = try(var.alarms.custom_values.sqliruleset.period, 60)
-      statistic = try(var.alarms.custom_values.sqliruleset.statistic, "count")
-      threshold = try(var.alarms.custom_values.sqliruleset.threshold, 100)
+      period                 = try(var.alarms.custom_values.sqliruleset.period, 60)
+      statistic              = try(var.alarms.custom_values.sqliruleset.statistic, "count")
+      threshold              = try(var.alarms.custom_values.sqliruleset.threshold, 100)
+      fill_insufficient_data = try(var.alarms.custom_values.sqliruleset.fill_insufficient_data, true)
     },
     {
       name   = "WAF: Rising Blocking Activity for Unix Rules on ${var.name}"
@@ -86,9 +92,10 @@ module "alerts" {
         Rule   = "AWS-AWSManagedRulesUnixRuleSet",
         Region = data.aws_region.current.name
       }
-      period    = try(var.alarms.custom_values.unixruleset.period, 60)
-      statistic = try(var.alarms.custom_values.unixruleset.statistic, "count")
-      threshold = try(var.alarms.custom_values.unixruleset.threshold, 100)
+      period                 = try(var.alarms.custom_values.unixruleset.period, 60)
+      statistic              = try(var.alarms.custom_values.unixruleset.statistic, "count")
+      threshold              = try(var.alarms.custom_values.unixruleset.threshold, 100)
+      fill_insufficient_data = try(var.alarms.custom_values.unixruleset.fill_insufficient_data, true)
     },
   ]
   enable_insufficient_data_actions = false


### PR DESCRIPTION
1. updated alerts module version for waf module
2. updated alerts module version for cloudtrail module

New version sets fill_insufficient_data parameter to true for those 2 modules, which means that these alerts' metrics will get 0 value as data in case there is not any data.
Via this PR we won't get 'Insufficient Data' status alerts.