### PR TITLE
fix(DMVP-4914): have default for protected_tags variable with tag prefixes and wildcards which will not be removed by image cleanup job

### DIFF
--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -41,7 +41,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 0.35.0 |
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 0.41.1 |
 
 ## Resources
 
@@ -54,7 +54,7 @@ No resources.
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: MUTABLE or IMMUTABLE | `string` | `"MUTABLE"` | no |
 | <a name="input_max_image_count"></a> [max\_image\_count](#input\_max\_image\_count) | How many Docker Image versions AWS ECR will store. | `number` | `20` | no |
 | <a name="input_principals_readonly_access"></a> [principals\_readonly\_access](#input\_principals\_readonly\_access) | Principal ARNs to provide with readonly access to the ECR | `list(string)` | `[]` | no |
-| <a name="input_protected_tags"></a> [protected\_tags](#input\_protected\_tags) | Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod` | `set(string)` | `[]` | no |
+| <a name="input_protected_tags"></a> [protected\_tags](#input\_protected\_tags) | Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod` | `set(string)` | <pre>[<br>  "prod",<br>  "image-keep"<br>]</pre> | no |
 | <a name="input_repos"></a> [repos](#input\_repos) | 0 out of 256 characters maximum (2 minimum). The name must start with a letter and can only contain lowercase letters, numbers, hyphens, underscores, and forward slashes. | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -31,7 +31,7 @@ module "ecr" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.22.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.22.0 |
 
 ## Providers
 
@@ -41,7 +41,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 0.41.1 |
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | git::https://github.com/dasmeta/terraform-aws-ecr.git | main |
 
 ## Resources
 
@@ -54,7 +54,7 @@ No resources.
 | <a name="input_image_tag_mutability"></a> [image\_tag\_mutability](#input\_image\_tag\_mutability) | The tag mutability setting for the repository. Must be one of: MUTABLE or IMMUTABLE | `string` | `"MUTABLE"` | no |
 | <a name="input_max_image_count"></a> [max\_image\_count](#input\_max\_image\_count) | How many Docker Image versions AWS ECR will store. | `number` | `20` | no |
 | <a name="input_principals_readonly_access"></a> [principals\_readonly\_access](#input\_principals\_readonly\_access) | Principal ARNs to provide with readonly access to the ECR | `list(string)` | `[]` | no |
-| <a name="input_protected_tags"></a> [protected\_tags](#input\_protected\_tags) | Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod` | `set(string)` | <pre>[<br>  "prod",<br>  "image-keep"<br>]</pre> | no |
+| <a name="input_protected_tags"></a> [protected\_tags](#input\_protected\_tags) | Image tags patterns (prefixes and wildcards) that should not be destroyed. If item contains asterisk symbol('*') it considered as wildcard, overwise as prefix matching | `set(string)` | <pre>[<br>  "latest",<br>  "image-keep",<br>  "*prod*",<br>  "*.*.*"<br>]</pre> | no |
 | <a name="input_repos"></a> [repos](#input\_repos) | 0 out of 256 characters maximum (2 minimum). The name must start with a letter and can only contain lowercase letters, numbers, hyphens, underscores, and forward slashes. | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,6 +1,6 @@
 module "ecr" {
   source = "git::https://github.com/dasmeta/terraform-aws-ecr.git?ref=main"
-  # TODO: we module with direct github repo source because there was need some ability, please check PR: https://github.com/cloudposse/terraform-aws-ecr/issues/133 and uncomment source to tf registry
+  # TODO: we have module with direct github repo source now because there was need protected tags wildcard match ability. please check PR: https://github.com/cloudposse/terraform-aws-ecr/issues/133 and uncomment source/version to the original module tf registry
   # source  = "cloudposse/ecr/aws"
   # version = "0.41.1"
 

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,6 +1,8 @@
 module "ecr" {
-  source  = "cloudposse/ecr/aws"
-  version = "0.41.1"
+  source = "git::https://github.com/dasmeta/terraform-aws-ecr.git?ref=main"
+  # TODO: we module with direct github repo source because there was need some ability, please check PR: https://github.com/cloudposse/terraform-aws-ecr/issues/133 and uncomment source to tf registry
+  # source  = "cloudposse/ecr/aws"
+  # version = "0.41.1"
 
   for_each = { for repo in var.repos : repo => repo }
 

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,6 +1,6 @@
 module "ecr" {
   source  = "cloudposse/ecr/aws"
-  version = "0.35.0"
+  version = "0.41.1"
 
   for_each = { for repo in var.repos : repo => repo }
 

--- a/modules/ecr/tests/basic/0-setup.tf
+++ b/modules/ecr/tests/basic/0-setup.tf
@@ -1,9 +1,5 @@
 terraform {
   required_providers {
-    test = {
-      source = "terraform.io/builtin/test"
-    }
-
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.22.0"

--- a/modules/ecr/tests/basic/2-assert.tf
+++ b/modules/ecr/tests/basic/2-assert.tf
@@ -1,9 +1,0 @@
-resource "test_assertions" "dummy" {
-  component = "this"
-
-  equal "scheme" {
-    description = "As module does not have any output and data just make sure the case runs. Probably can be thrown away."
-    got         = "all good"
-    want        = "all good"
-  }
-}

--- a/modules/ecr/tests/basic/README.md
+++ b/modules/ecr/tests/basic/README.md
@@ -14,9 +14,7 @@ This example creates 2 repositories and applies default lifecycle policies for t
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_test"></a> [test](#provider\_test) | n/a |
+No providers.
 
 ## Modules
 
@@ -26,9 +24,7 @@ This example creates 2 repositories and applies default lifecycle policies for t
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| test_assertions.dummy | resource |
+No resources.
 
 ## Inputs
 

--- a/modules/ecr/tests/lifecycle_policy/0-setup.tf
+++ b/modules/ecr/tests/lifecycle_policy/0-setup.tf
@@ -1,8 +1,5 @@
 terraform {
   required_providers {
-    test = {
-      source = "terraform.io/builtin/test"
-    }
 
     aws = {
       source  = "hashicorp/aws"

--- a/modules/ecr/tests/lifecycle_policy/2-assert.tf
+++ b/modules/ecr/tests/lifecycle_policy/2-assert.tf
@@ -1,9 +1,0 @@
-resource "test_assertions" "dummy" {
-  component = "this"
-
-  equal "scheme" {
-    description = "As module does not have any output and data just make sure the case runs. Probably can be thrown away."
-    got         = "all good"
-    want        = "all good"
-  }
-}

--- a/modules/ecr/tests/lifecycle_policy/README.md
+++ b/modules/ecr/tests/lifecycle_policy/README.md
@@ -18,9 +18,7 @@ To change tags for imgaes, change `protected_tags` value.
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_test"></a> [test](#provider\_test) | n/a |
+No providers.
 
 ## Modules
 
@@ -30,9 +28,7 @@ To change tags for imgaes, change `protected_tags` value.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| test_assertions.dummy | resource |
+No resources.
 
 ## Inputs
 

--- a/modules/ecr/tests/read_only_access/0-setup.tf
+++ b/modules/ecr/tests/read_only_access/0-setup.tf
@@ -1,9 +1,5 @@
 terraform {
   required_providers {
-    test = {
-      source = "terraform.io/builtin/test"
-    }
-
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.22.0"

--- a/modules/ecr/tests/read_only_access/2-assert.tf
+++ b/modules/ecr/tests/read_only_access/2-assert.tf
@@ -1,9 +1,0 @@
-resource "test_assertions" "dummy" {
-  component = "this"
-
-  equal "scheme" {
-    description = "As module does not have any output and data just make sure the case runs. Probably can be thrown away."
-    got         = "all good"
-    want        = "all good"
-  }
-}

--- a/modules/ecr/tests/read_only_access/README.md
+++ b/modules/ecr/tests/read_only_access/README.md
@@ -14,9 +14,7 @@ This example creates 2 repositories and applies default lifecycle policies for t
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_test"></a> [test](#provider\_test) | n/a |
+No providers.
 
 ## Modules
 
@@ -26,9 +24,7 @@ This example creates 2 repositories and applies default lifecycle policies for t
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| test_assertions.dummy | resource |
+No resources.
 
 ## Inputs
 

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -12,10 +12,12 @@ variable "max_image_count" {
 
 variable "protected_tags" {
   type        = set(string)
-  description = "Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod`"
+  description = "Image tags patterns (prefixes and wildcards) that should not be destroyed. If item contains asterisk symbol('*') it considered as wildcard, overwise as prefix matching"
   default = [
-    "prod",
-    "image-keep"
+    "latest",
+    "image-keep",
+    "*prod*",
+    "*.*.*"
   ]
 }
 

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -13,7 +13,10 @@ variable "max_image_count" {
 variable "protected_tags" {
   type        = set(string)
   description = "Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod`"
-  default     = []
+  default = [
+    "prod",
+    "image-keep"
+  ]
 }
 
 variable "image_tag_mutability" {

--- a/modules/ecr/versions.tf
+++ b/modules/ecr/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.22.0"
+      version = ">= 4.22.0"
     }
   }
 }

--- a/modules/ingress/tests/basic/README.md
+++ b/modules/ingress/tests/basic/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.41 |
 
 ## Modules
 

--- a/modules/ingress/tests/enable_s3_logs/README.md
+++ b/modules/ingress/tests/enable_s3_logs/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.41 |
 
 ## Modules
 

--- a/modules/ingress/tests/multiple-domains/README.md
+++ b/modules/ingress/tests/multiple-domains/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 


### PR DESCRIPTION
fix(DMVP-4914): have default for protected_tags variable with tag prefixes which will not be removed by image cleanup job