### PR TITLE
feat(nlb): add network load balancer module

### DIFF
--- a/.github/workflows/checkov.yaml
+++ b/.github/workflows/checkov.yaml
@@ -62,6 +62,7 @@ jobs:
           - modules/metrics-server
           - modules/mongodb-atlas
           - modules/mongodb
+          - modules/nlb
           - modules/rabbitmq
           - modules/rds
           - modules/route53-alerts-notify

--- a/.github/workflows/terraform-test.yaml
+++ b/.github/workflows/terraform-test.yaml
@@ -61,6 +61,7 @@ jobs:
           - modules/metrics-server
           - modules/mongodb-atlas
           - modules/mongodb
+          - modules/nlb
           - modules/rabbitmq
           - modules/rds
           - modules/route53-alerts-notify

--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -63,6 +63,7 @@ jobs:
           - modules/metrics-server
           - modules/mongodb-atlas
           - modules/mongodb
+          - modules/nlb
           - modules/rabbitmq
           - modules/rds
           - modules/route53-alerts-notify

--- a/modules/nlb/README.md
+++ b/modules/nlb/README.md
@@ -1,0 +1,137 @@
+# AWS Network Load Balancer
+
+This module creates a reusable AWS Network Load Balancer with listener, target group, target attachment, security group allowlist, and target-health alarm support.
+
+It wraps `terraform-aws-modules/alb/aws` with `load_balancer_type = "network"` and exposes a smaller interface for common NLB use cases.
+
+## Usage
+
+```hcl
+module "nlb" {
+  source = "dasmeta/modules/aws//modules/nlb"
+
+  name       = "example-nlb"
+  vpc_id     = "vpc-12345678"
+  subnet_ids = ["subnet-11111111", "subnet-22222222"]
+
+  allowed_cidr_blocks = ["203.0.113.10/32"]
+
+  listeners = {
+    tcp = {
+      port             = 3306
+      protocol         = "TCP"
+      target_group_key = "tcp"
+    }
+  }
+
+  target_groups = {
+    tcp = {
+      port        = 3306
+      protocol    = "TCP"
+      target_type = "ip"
+
+      health_check = {
+        protocol = "TCP"
+        port     = "traffic-port"
+      }
+
+      targets = {
+        primary = {
+          target_id = "10.0.1.10"
+          port      = 3306
+        }
+      }
+    }
+  }
+
+  alarms = {
+    enabled       = true
+    alarm_actions = ["arn:aws:sns:eu-central-1:123456789012:example-alerts"]
+  }
+}
+```
+
+## Security Groups
+
+When `create_security_group` is true, the module creates and attaches a Network Load Balancer security group. Listener ports are opened only to `allowed_cidr_blocks` and `allowed_ipv6_cidr_blocks`.
+
+For a single trusted IP, pass a `/32` CIDR:
+
+```hcl
+allowed_cidr_blocks = ["203.0.113.10/32"]
+```
+
+AWS requires Network Load Balancer security groups to be associated when the load balancer is created. If an NLB is created without security groups, they cannot be added to that NLB later without replacement. Keep `create_security_group = true` or pass `security_group_ids` during initial creation when allowlisting is required.
+
+## Target Health Alarms
+
+When `alarms.enabled` is true, the module creates one CloudWatch alarm per target group for `AWS/NetworkELB` `UnHealthyHostCount`.
+
+Notification actions are caller-owned. Pass SNS topic ARNs or other CloudWatch alarm action ARNs with `alarms.alarm_actions`.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.99 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.56.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_this"></a> [this](#module\_this) | terraform-aws-modules/alb/aws | ~> 9.17 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [aws_cloudwatch_metric_alarm.target_unhealthy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_alarms"></a> [alarms](#input\_alarms) | Target-health CloudWatch alarm configuration. Alarm actions are caller-owned. | <pre>object({<br/>    enabled                   = optional(bool, false)<br/>    alarm_actions             = optional(list(string), [])<br/>    ok_actions                = optional(list(string), [])<br/>    insufficient_data_actions = optional(list(string), [])<br/>    name_prefix               = optional(string, "")<br/>    threshold                 = optional(number, 0)<br/>    comparison_operator       = optional(string, "GreaterThanThreshold")<br/>    evaluation_periods        = optional(number, 1)<br/>    datapoints_to_alarm       = optional(number)<br/>    period                    = optional(number, 60)<br/>    statistic                 = optional(string, "Maximum")<br/>    treat_missing_data        = optional(string, "notBreaching")<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |
+| <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | IPv4 CIDR blocks allowed to reach listener ports on the module-managed security group. | `list(string)` | `[]` | no |
+| <a name="input_allowed_ipv6_cidr_blocks"></a> [allowed\_ipv6\_cidr\_blocks](#input\_allowed\_ipv6\_cidr\_blocks) | IPv6 CIDR blocks allowed to reach listener ports on the module-managed security group. | `list(string)` | `[]` | no |
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Whether to create and attach a module-managed security group to the Network Load Balancer. | `bool` | `true` | no |
+| <a name="input_egress_cidr_blocks"></a> [egress\_cidr\_blocks](#input\_egress\_cidr\_blocks) | IPv4 CIDR blocks allowed for outbound traffic from the module-managed security group. | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
+| <a name="input_egress_ipv6_cidr_blocks"></a> [egress\_ipv6\_cidr\_blocks](#input\_egress\_ipv6\_cidr\_blocks) | IPv6 CIDR blocks allowed for outbound traffic from the module-managed security group. | `list(string)` | `[]` | no |
+| <a name="input_enable_cross_zone_load_balancing"></a> [enable\_cross\_zone\_load\_balancing](#input\_enable\_cross\_zone\_load\_balancing) | Whether cross-zone load balancing is enabled for the Network Load Balancer. | `bool` | `true` | no |
+| <a name="input_enable_deletion_protection"></a> [enable\_deletion\_protection](#input\_enable\_deletion\_protection) | Whether deletion protection is enabled for the Network Load Balancer. | `bool` | `false` | no |
+| <a name="input_internal"></a> [internal](#input\_internal) | Whether the Network Load Balancer is internal. | `bool` | `true` | no |
+| <a name="input_ip_address_type"></a> [ip\_address\_type](#input\_ip\_address\_type) | IP address type for the Network Load Balancer. | `string` | `"ipv4"` | no |
+| <a name="input_listeners"></a> [listeners](#input\_listeners) | Map of Network Load Balancer listeners keyed by logical listener name. | <pre>map(object({<br/>    port                     = number<br/>    protocol                 = optional(string, "TCP")<br/>    target_group_key         = string<br/>    certificate_arn          = optional(string)<br/>    ssl_policy               = optional(string)<br/>    alpn_policy              = optional(string)<br/>    tcp_idle_timeout_seconds = optional(number)<br/>  }))</pre> | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the Network Load Balancer. | `string` | n/a | yes |
+| <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | Description for the module-managed security group. | `string` | `null` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Existing security group IDs to attach to the Network Load Balancer. | `list(string)` | `[]` | no |
+| <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Name for the module-managed security group. Defaults to name. | `string` | `null` | no |
+| <a name="input_security_group_use_name_prefix"></a> [security\_group\_use\_name\_prefix](#input\_security\_group\_use\_name\_prefix) | Whether security\_group\_name is used as a name prefix. | `bool` | `false` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to attach to the Network Load Balancer. | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to supported resources. | `map(string)` | `{}` | no |
+| <a name="input_target_groups"></a> [target\_groups](#input\_target\_groups) | Map of target groups keyed by logical target group name. | <pre>map(object({<br/>    name                 = optional(string)<br/>    name_prefix          = optional(string)<br/>    port                 = number<br/>    protocol             = optional(string, "TCP")<br/>    target_type          = optional(string, "ip")<br/>    deregistration_delay = optional(number)<br/>    preserve_client_ip   = optional(bool)<br/>    proxy_protocol_v2    = optional(bool)<br/>    health_check = optional(object({<br/>      enabled             = optional(bool)<br/>      healthy_threshold   = optional(number)<br/>      interval            = optional(number)<br/>      matcher             = optional(string)<br/>      path                = optional(string)<br/>      port                = optional(string)<br/>      protocol            = optional(string)<br/>      timeout             = optional(number)<br/>      unhealthy_threshold = optional(number)<br/>    }), {})<br/>    targets = optional(map(object({<br/>      target_id         = string<br/>      port              = optional(number)<br/>      availability_zone = optional(string)<br/>    })), {})<br/>  }))</pre> | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC where target groups and optional security group are created. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_lb_arn"></a> [lb\_arn](#output\_lb\_arn) | ARN of the Network Load Balancer. |
+| <a name="output_lb_arn_suffix"></a> [lb\_arn\_suffix](#output\_lb\_arn\_suffix) | ARN suffix of the Network Load Balancer for CloudWatch dimensions. |
+| <a name="output_lb_dns_name"></a> [lb\_dns\_name](#output\_lb\_dns\_name) | DNS name of the Network Load Balancer. |
+| <a name="output_lb_zone_id"></a> [lb\_zone\_id](#output\_lb\_zone\_id) | Route53 zone ID of the Network Load Balancer. |
+| <a name="output_listener_arns"></a> [listener\_arns](#output\_listener\_arns) | ARNs of listeners created by this module. |
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | ARN of the module-managed security group, when created. |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the module-managed security group, when created. |
+| <a name="output_target_group_arn_suffixes"></a> [target\_group\_arn\_suffixes](#output\_target\_group\_arn\_suffixes) | ARN suffixes of target groups for CloudWatch dimensions. |
+| <a name="output_target_group_arns"></a> [target\_group\_arns](#output\_target\_group\_arns) | ARNs of target groups created by this module. |
+| <a name="output_target_unhealthy_alarm_arns"></a> [target\_unhealthy\_alarm\_arns](#output\_target\_unhealthy\_alarm\_arns) | ARNs of target unhealthy CloudWatch alarms. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nlb/main.tf
+++ b/modules/nlb/main.tf
@@ -1,0 +1,168 @@
+locals {
+  listener_security_group_ports = flatten([
+    for listener_key, listener in var.listeners : [
+      for protocol in upper(listener.protocol) == "TCP_UDP" ? ["tcp", "udp"] : upper(listener.protocol) == "UDP" ? ["udp"] : ["tcp"] : {
+        key      = listener_key
+        port     = listener.port
+        protocol = protocol
+      }
+    ]
+  ])
+
+  security_group_ingress_ipv4_rules = {
+    for rule in flatten([
+      for listener in local.listener_security_group_ports : [
+        for cidr in var.allowed_cidr_blocks : {
+          key = "${listener.key}-${listener.protocol}-ipv4-${substr(sha1(cidr), 0, 8)}"
+          value = {
+            cidr_ipv4   = cidr
+            description = "Allow ${listener.protocol} ${listener.port} from ${cidr}"
+            from_port   = listener.port
+            ip_protocol = listener.protocol
+            to_port     = listener.port
+          }
+        }
+      ]
+    ]) : rule.key => rule.value
+  }
+
+  security_group_ingress_ipv6_rules = {
+    for rule in flatten([
+      for listener in local.listener_security_group_ports : [
+        for cidr in var.allowed_ipv6_cidr_blocks : {
+          key = "${listener.key}-${listener.protocol}-ipv6-${substr(sha1(cidr), 0, 8)}"
+          value = {
+            cidr_ipv6   = cidr
+            description = "Allow ${listener.protocol} ${listener.port} from ${cidr}"
+            from_port   = listener.port
+            ip_protocol = listener.protocol
+            to_port     = listener.port
+          }
+        }
+      ]
+    ]) : rule.key => rule.value
+  }
+
+  security_group_egress_ipv4_rules = {
+    for index, cidr in var.egress_cidr_blocks : "egress-ipv4-${index}" => {
+      cidr_ipv4   = cidr
+      description = "Allow outbound IPv4 traffic to ${cidr}"
+      ip_protocol = "-1"
+    }
+  }
+
+  security_group_egress_ipv6_rules = {
+    for index, cidr in var.egress_ipv6_cidr_blocks : "egress-ipv6-${index}" => {
+      cidr_ipv6   = cidr
+      description = "Allow outbound IPv6 traffic to ${cidr}"
+      ip_protocol = "-1"
+    }
+  }
+
+  listeners = {
+    for listener_key, listener in var.listeners : listener_key => merge(
+      {
+        forward = {
+          target_group_key = listener.target_group_key
+        }
+        port     = listener.port
+        protocol = upper(listener.protocol)
+      },
+      listener.certificate_arn == null ? {} : { certificate_arn = listener.certificate_arn },
+      listener.ssl_policy == null ? {} : { ssl_policy = listener.ssl_policy },
+      listener.alpn_policy == null ? {} : { alpn_policy = listener.alpn_policy },
+      listener.tcp_idle_timeout_seconds == null ? {} : { tcp_idle_timeout_seconds = listener.tcp_idle_timeout_seconds }
+    )
+  }
+
+  target_groups = {
+    for target_group_key, target_group in var.target_groups : target_group_key => merge(
+      {
+        create_attachment = false
+        health_check      = target_group.health_check
+        port              = target_group.port
+        protocol          = upper(target_group.protocol)
+        target_type       = lower(target_group.target_type)
+        vpc_id            = var.vpc_id
+      },
+      target_group.name_prefix != null ? { name_prefix = target_group.name_prefix } : { name = coalesce(target_group.name, substr("${var.name}-${target_group_key}", 0, 32)) },
+      target_group.deregistration_delay == null ? {} : { deregistration_delay = target_group.deregistration_delay },
+      target_group.preserve_client_ip == null ? {} : { preserve_client_ip = target_group.preserve_client_ip },
+      target_group.proxy_protocol_v2 == null ? {} : { proxy_protocol_v2 = target_group.proxy_protocol_v2 }
+    )
+  }
+
+  target_group_attachments = flatten([
+    for target_group_key, target_group in var.target_groups : [
+      for target_key, target in target_group.targets : {
+        key = "${target_group_key}-${target_key}"
+        value = merge(
+          {
+            target_group_key = target_group_key
+            target_id        = target.target_id
+          },
+          target.port == null ? {} : { port = target.port },
+          target.availability_zone == null ? {} : { availability_zone = target.availability_zone }
+        )
+      }
+    ]
+  ])
+}
+
+module "this" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 9.17"
+
+  name               = var.name
+  load_balancer_type = "network"
+  internal           = var.internal
+  ip_address_type    = var.ip_address_type
+  subnets            = var.subnet_ids
+  vpc_id             = var.vpc_id
+
+  enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing
+  enable_deletion_protection       = var.enable_deletion_protection
+
+  listeners                           = local.listeners
+  target_groups                       = local.target_groups
+  additional_target_group_attachments = { for attachment in local.target_group_attachments : attachment.key => attachment.value }
+
+  create_security_group          = var.create_security_group
+  security_group_name            = coalesce(var.security_group_name, var.name)
+  security_group_use_name_prefix = var.security_group_use_name_prefix
+  security_group_description     = coalesce(var.security_group_description, "Security group for ${var.name} Network Load Balancer")
+  security_groups                = var.security_group_ids
+  security_group_ingress_rules   = merge(local.security_group_ingress_ipv4_rules, local.security_group_ingress_ipv6_rules)
+  security_group_egress_rules    = merge(local.security_group_egress_ipv4_rules, local.security_group_egress_ipv6_rules)
+  security_group_tags            = var.tags
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "target_unhealthy" {
+  for_each = var.alarms.enabled ? var.target_groups : {}
+
+  alarm_name                = "${var.alarms.name_prefix}${var.name}-${each.key}-unhealthy-targets"
+  alarm_description         = "Network Load Balancer target group ${each.key} has unhealthy targets."
+  namespace                 = "AWS/NetworkELB"
+  metric_name               = "UnHealthyHostCount"
+  comparison_operator       = var.alarms.comparison_operator
+  evaluation_periods        = var.alarms.evaluation_periods
+  datapoints_to_alarm       = var.alarms.datapoints_to_alarm
+  period                    = var.alarms.period
+  statistic                 = var.alarms.statistic
+  threshold                 = var.alarms.threshold
+  treat_missing_data        = var.alarms.treat_missing_data
+  alarm_actions             = var.alarms.alarm_actions
+  ok_actions                = var.alarms.ok_actions
+  insufficient_data_actions = var.alarms.insufficient_data_actions
+
+  dimensions = {
+    LoadBalancer = module.this.arn_suffix
+    TargetGroup  = module.this.target_groups[each.key].arn_suffix
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-${each.key}-unhealthy-targets"
+  })
+}

--- a/modules/nlb/outputs.tf
+++ b/modules/nlb/outputs.tf
@@ -1,0 +1,49 @@
+output "lb_arn" {
+  description = "ARN of the Network Load Balancer."
+  value       = module.this.arn
+}
+
+output "lb_arn_suffix" {
+  description = "ARN suffix of the Network Load Balancer for CloudWatch dimensions."
+  value       = module.this.arn_suffix
+}
+
+output "lb_dns_name" {
+  description = "DNS name of the Network Load Balancer."
+  value       = module.this.dns_name
+}
+
+output "lb_zone_id" {
+  description = "Route53 zone ID of the Network Load Balancer."
+  value       = module.this.zone_id
+}
+
+output "listener_arns" {
+  description = "ARNs of listeners created by this module."
+  value       = { for key, listener in module.this.listeners : key => listener.arn }
+}
+
+output "target_group_arns" {
+  description = "ARNs of target groups created by this module."
+  value       = { for key, target_group in module.this.target_groups : key => target_group.arn }
+}
+
+output "target_group_arn_suffixes" {
+  description = "ARN suffixes of target groups for CloudWatch dimensions."
+  value       = { for key, target_group in module.this.target_groups : key => target_group.arn_suffix }
+}
+
+output "security_group_id" {
+  description = "ID of the module-managed security group, when created."
+  value       = module.this.security_group_id
+}
+
+output "security_group_arn" {
+  description = "ARN of the module-managed security group, when created."
+  value       = module.this.security_group_arn
+}
+
+output "target_unhealthy_alarm_arns" {
+  description = "ARNs of target unhealthy CloudWatch alarms."
+  value       = { for key, alarm in aws_cloudwatch_metric_alarm.target_unhealthy : key => alarm.arn }
+}

--- a/modules/nlb/tests/basic/0-setup.tf
+++ b/modules/nlb/tests/basic/0-setup.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.99"
+    }
+  }
+}

--- a/modules/nlb/tests/basic/1-example.tf
+++ b/modules/nlb/tests/basic/1-example.tf
@@ -1,0 +1,46 @@
+module "this" {
+  source = "../.."
+
+  name       = "example-nlb"
+  vpc_id     = "vpc-12345678"
+  subnet_ids = ["subnet-11111111", "subnet-22222222"]
+
+  allowed_cidr_blocks = ["203.0.113.10/32"]
+
+  listeners = {
+    tcp = {
+      port             = 3306
+      protocol         = "TCP"
+      target_group_key = "tcp"
+    }
+  }
+
+  target_groups = {
+    tcp = {
+      port        = 3306
+      protocol    = "TCP"
+      target_type = "ip"
+
+      health_check = {
+        protocol = "TCP"
+        port     = "traffic-port"
+      }
+
+      targets = {
+        primary = {
+          target_id = "10.0.1.10"
+          port      = 3306
+        }
+      }
+    }
+  }
+
+  alarms = {
+    enabled       = true
+    alarm_actions = ["arn:aws:sns:eu-central-1:123456789012:example-alerts"]
+  }
+
+  tags = {
+    Environment = "test"
+  }
+}

--- a/modules/nlb/tests/basic/2-assert.tf
+++ b/modules/nlb/tests/basic/2-assert.tf
@@ -1,0 +1,14 @@
+output "lb_dns_name" {
+  description = "DNS name of the created Network Load Balancer."
+  value       = module.this.lb_dns_name
+}
+
+output "security_group_id" {
+  description = "ID of the module-managed Network Load Balancer security group."
+  value       = module.this.security_group_id
+}
+
+output "target_unhealthy_alarm_arns" {
+  description = "ARNs of unhealthy-target alarms created by the module."
+  value       = module.this.target_unhealthy_alarm_arns
+}

--- a/modules/nlb/tests/basic/README.md
+++ b/modules/nlb/tests/basic/README.md
@@ -1,0 +1,42 @@
+# Basic NLB Example
+
+This example validates a generic Network Load Balancer with:
+
+- one TCP listener
+- one IP target group
+- one `/32` IPv4 allowlist
+- target unhealthy alarms with a caller-owned SNS action
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.99 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_this"></a> [this](#module\_this) | ../.. | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_lb_dns_name"></a> [lb\_dns\_name](#output\_lb\_dns\_name) | DNS name of the created Network Load Balancer. |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the module-managed Network Load Balancer security group. |
+| <a name="output_target_unhealthy_alarm_arns"></a> [target\_unhealthy\_alarm\_arns](#output\_target\_unhealthy\_alarm\_arns) | ARNs of unhealthy-target alarms created by the module. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nlb/variables.tf
+++ b/modules/nlb/variables.tf
@@ -1,0 +1,221 @@
+variable "name" {
+  type        = string
+  description = "Name of the Network Load Balancer."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "ID of the VPC where target groups and optional security group are created."
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs to attach to the Network Load Balancer."
+}
+
+variable "internal" {
+  type        = bool
+  default     = true
+  description = "Whether the Network Load Balancer is internal."
+}
+
+variable "enable_deletion_protection" {
+  type        = bool
+  default     = false
+  description = "Whether deletion protection is enabled for the Network Load Balancer."
+}
+
+variable "enable_cross_zone_load_balancing" {
+  type        = bool
+  default     = true
+  description = "Whether cross-zone load balancing is enabled for the Network Load Balancer."
+}
+
+variable "ip_address_type" {
+  type        = string
+  default     = "ipv4"
+  description = "IP address type for the Network Load Balancer."
+
+  validation {
+    condition     = contains(["ipv4", "dualstack"], var.ip_address_type)
+    error_message = "ip_address_type must be either ipv4 or dualstack."
+  }
+}
+
+variable "listeners" {
+  type = map(object({
+    port                     = number
+    protocol                 = optional(string, "TCP")
+    target_group_key         = string
+    certificate_arn          = optional(string)
+    ssl_policy               = optional(string)
+    alpn_policy              = optional(string)
+    tcp_idle_timeout_seconds = optional(number)
+  }))
+  description = "Map of Network Load Balancer listeners keyed by logical listener name."
+
+  validation {
+    condition = alltrue([
+      for listener in values(var.listeners) : contains(["TCP", "TLS", "UDP", "TCP_UDP"], upper(listener.protocol))
+    ])
+    error_message = "Listener protocol must be one of TCP, TLS, UDP, or TCP_UDP."
+  }
+
+  validation {
+    condition = alltrue([
+      for listener in values(var.listeners) : upper(listener.protocol) != "TLS" || listener.certificate_arn != null
+    ])
+    error_message = "TLS listeners must include certificate_arn."
+  }
+}
+
+variable "target_groups" {
+  type = map(object({
+    name                 = optional(string)
+    name_prefix          = optional(string)
+    port                 = number
+    protocol             = optional(string, "TCP")
+    target_type          = optional(string, "ip")
+    deregistration_delay = optional(number)
+    preserve_client_ip   = optional(bool)
+    proxy_protocol_v2    = optional(bool)
+    health_check = optional(object({
+      enabled             = optional(bool)
+      healthy_threshold   = optional(number)
+      interval            = optional(number)
+      matcher             = optional(string)
+      path                = optional(string)
+      port                = optional(string)
+      protocol            = optional(string)
+      timeout             = optional(number)
+      unhealthy_threshold = optional(number)
+    }), {})
+    targets = optional(map(object({
+      target_id         = string
+      port              = optional(number)
+      availability_zone = optional(string)
+    })), {})
+  }))
+  description = "Map of target groups keyed by logical target group name."
+
+  validation {
+    condition = alltrue([
+      for target_group in values(var.target_groups) : contains(["TCP", "TLS", "UDP", "TCP_UDP"], upper(target_group.protocol))
+    ])
+    error_message = "Target group protocol must be one of TCP, TLS, UDP, or TCP_UDP."
+  }
+
+  validation {
+    condition = alltrue([
+      for target_group in values(var.target_groups) : contains(["ip", "instance", "alb"], lower(target_group.target_type))
+    ])
+    error_message = "target_type must be one of ip, instance, or alb."
+  }
+
+  validation {
+    condition = alltrue([
+      for target_group in values(var.target_groups) : !(target_group.name != null && target_group.name_prefix != null)
+    ])
+    error_message = "Use either target group name or name_prefix, not both."
+  }
+}
+
+variable "create_security_group" {
+  type        = bool
+  default     = true
+  description = "Whether to create and attach a module-managed security group to the Network Load Balancer."
+}
+
+variable "security_group_name" {
+  type        = string
+  default     = null
+  description = "Name for the module-managed security group. Defaults to name."
+}
+
+variable "security_group_use_name_prefix" {
+  type        = bool
+  default     = false
+  description = "Whether security_group_name is used as a name prefix."
+}
+
+variable "security_group_description" {
+  type        = string
+  default     = null
+  description = "Description for the module-managed security group."
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "Existing security group IDs to attach to the Network Load Balancer."
+}
+
+variable "allowed_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "IPv4 CIDR blocks allowed to reach listener ports on the module-managed security group."
+
+  validation {
+    condition = alltrue([
+      for cidr in var.allowed_cidr_blocks : can(cidrnetmask(cidr))
+    ])
+    error_message = "allowed_cidr_blocks must contain valid IPv4 CIDR blocks."
+  }
+}
+
+variable "allowed_ipv6_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "IPv6 CIDR blocks allowed to reach listener ports on the module-managed security group."
+
+  validation {
+    condition = alltrue([
+      for cidr in var.allowed_ipv6_cidr_blocks : can(cidrhost(cidr, 0))
+    ])
+    error_message = "allowed_ipv6_cidr_blocks must contain valid IPv6 CIDR blocks."
+  }
+}
+
+variable "egress_cidr_blocks" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "IPv4 CIDR blocks allowed for outbound traffic from the module-managed security group."
+}
+
+variable "egress_ipv6_cidr_blocks" {
+  type        = list(string)
+  default     = []
+  description = "IPv6 CIDR blocks allowed for outbound traffic from the module-managed security group."
+}
+
+variable "alarms" {
+  type = object({
+    enabled                   = optional(bool, false)
+    alarm_actions             = optional(list(string), [])
+    ok_actions                = optional(list(string), [])
+    insufficient_data_actions = optional(list(string), [])
+    name_prefix               = optional(string, "")
+    threshold                 = optional(number, 0)
+    comparison_operator       = optional(string, "GreaterThanThreshold")
+    evaluation_periods        = optional(number, 1)
+    datapoints_to_alarm       = optional(number)
+    period                    = optional(number, 60)
+    statistic                 = optional(string, "Maximum")
+    treat_missing_data        = optional(string, "notBreaching")
+  })
+  default = {
+    enabled = false
+  }
+  description = "Target-health CloudWatch alarm configuration. Alarm actions are caller-owned."
+
+  validation {
+    condition     = var.alarms.enabled == false || length(var.alarms.alarm_actions) > 0
+    error_message = "alarms.alarm_actions must contain at least one action ARN when alarms are enabled."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to supported resources."
+}

--- a/modules/nlb/versions.tf
+++ b/modules/nlb/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.99"
+    }
+  }
+}

--- a/specs/001-nlb-module/checklists/requirements.md
+++ b/specs/001-nlb-module/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Specification Quality Checklist: Generic AWS NLB Module
+
+**Purpose**: Validate specification completeness and quality before implementation
+**Created**: 2026-07-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details leak into stakeholder requirements beyond Terraform module scope
+- [x] Focused on user value and module consumer needs
+- [x] Written for infrastructure stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in success criteria
+- [x] Spec records missing `.specify/` repository bootstrap as a workflow exception
+
+## Notes
+
+- The repository does not contain `.specify/`; this package is a manual Speckit evidence package for the module change.

--- a/specs/001-nlb-module/contracts/module-interface.md
+++ b/specs/001-nlb-module/contracts/module-interface.md
@@ -1,0 +1,54 @@
+# Module Interface Contract: `modules/nlb`
+
+## Minimal Example
+
+```hcl
+module "nlb" {
+  source = "dasmeta/modules/aws//modules/nlb"
+
+  name       = "example-nlb"
+  vpc_id     = "vpc-12345678"
+  subnet_ids = ["subnet-11111111", "subnet-22222222"]
+
+  allowed_cidr_blocks = ["203.0.113.10/32"]
+
+  listeners = {
+    tcp = {
+      port             = 3306
+      protocol         = "TCP"
+      target_group_key = "tcp"
+    }
+  }
+
+  target_groups = {
+    tcp = {
+      port        = 3306
+      protocol    = "TCP"
+      target_type = "ip"
+      targets = {
+        primary = {
+          target_id = "10.0.1.10"
+          port      = 3306
+        }
+      }
+    }
+  }
+
+  alarms = {
+    enabled       = true
+    alarm_actions = ["arn:aws:sns:eu-central-1:123456789012:example-alerts"]
+  }
+}
+```
+
+## Required Outputs
+
+- `lb_arn`
+- `lb_arn_suffix`
+- `lb_dns_name`
+- `lb_zone_id`
+- `listener_arns`
+- `target_group_arns`
+- `target_group_arn_suffixes`
+- `security_group_id`
+- `target_unhealthy_alarm_arns`

--- a/specs/001-nlb-module/data-model.md
+++ b/specs/001-nlb-module/data-model.md
@@ -1,0 +1,51 @@
+# Data Model: Generic AWS NLB Module
+
+## NLB Configuration
+
+- `name`: Load balancer name.
+- `vpc_id`: VPC where target groups and optional security group are created.
+- `subnet_ids`: Subnets attached to the NLB.
+- `internal`: Whether the NLB is internal.
+- `tags`: Tags applied to supported resources.
+
+## Listener
+
+- `port`: Listener port.
+- `protocol`: TCP, TLS, UDP, or TCP_UDP.
+- `target_group_key`: Key of the target group receiving traffic.
+- `certificate_arn`: Required by consumers for TLS listeners.
+- `ssl_policy`: Optional TLS policy.
+
+## Target Group
+
+- `port`: Backend target port.
+- `protocol`: Backend protocol.
+- `target_type`: IP, instance, or alb.
+- `health_check`: Optional health-check override.
+- `targets`: Map of target attachments.
+
+## Target Attachment
+
+- `target_id`: Target IP, instance ID, or ALB ARN depending on target type.
+- `port`: Optional override target port.
+- `availability_zone`: Optional target availability zone.
+
+## Security Group Configuration
+
+- `create`: Whether to create a module-managed NLB security group.
+- `allowed_cidr_blocks`: IPv4 CIDR allowlist.
+- `allowed_ipv6_cidr_blocks`: IPv6 CIDR allowlist.
+- `security_group_ids`: Existing security groups to attach.
+- `egress_cidr_blocks`: IPv4 outbound CIDRs.
+- `egress_ipv6_cidr_blocks`: IPv6 outbound CIDRs.
+
+## Alarm Configuration
+
+- `enabled`: Whether target-health alarms are created.
+- `alarm_actions`: CloudWatch action ARNs to invoke on alarm.
+- `ok_actions`: CloudWatch action ARNs to invoke on recovery.
+- `threshold`: Unhealthy target threshold.
+- `period`: Alarm period.
+- `evaluation_periods`: Alarm evaluation periods.
+- `datapoints_to_alarm`: Optional datapoints to alarm.
+- `treat_missing_data`: Missing-data behavior.

--- a/specs/001-nlb-module/plan.md
+++ b/specs/001-nlb-module/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Generic AWS NLB Module
+
+**Branch**: `main` | **Date**: 2026-07-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/001-nlb-module/spec.md`
+
+## Summary
+
+Add `modules/nlb` as a generic, reusable AWS Network Load Balancer wrapper. The module will use `terraform-aws-modules/alb/aws` as the baseline for NLB/listener/target-group/security-group resources and add DasMeta-specific target-health CloudWatch alarms.
+
+## Technical Context
+
+**Language/Version**: Terraform >= 1.3.0
+**Primary Dependencies**: AWS provider >= 5.99, `terraform-aws-modules/alb/aws` ~> 9.17
+**Storage**: N/A
+**Testing**: `terraform fmt -check`, `terraform init -backend=false`, `terraform validate`
+**Target Platform**: AWS Network Load Balancer
+**Project Type**: Terraform module repository
+**Performance Goals**: No runtime code; generated AWS resources must remain limited to common NLB paths.
+**Constraints**: Generic module only; no staging or database-specific content; security groups must be created/attached at NLB creation time when used.
+**Scale/Scope**: One new module, one example test, workflow matrix additions.
+
+## Constitution Check
+
+- **Scope Gate**: PASS. Scope is limited to `modules/nlb`, its test, docs, and CI path listings.
+- **Ownership Gate**: PASS. Module ownership remains in this repository.
+- **Records Gate**: PASS WITH EXCEPTION. Repo lacks `.specify/`; local `specs/001-nlb-module` is the manually recorded evidence package.
+- **Controls Gate**: PASS. Terraform formatting and validation are defined.
+- **Change Gate**: PASS. This is additive and does not change existing module behavior.
+
+## Project Structure
+
+```text
+modules/nlb/
+├── main.tf
+├── variables.tf
+├── outputs.tf
+├── versions.tf
+├── README.md
+└── tests/
+    └── basic/
+        ├── 0-setup.tf
+        ├── 1-example.tf
+        ├── 2-assert.tf
+        └── README.md
+```
+
+## Pre-Change Plan
+
+### Current Repository Module State
+
+The repository contains many first-party modules under `modules/`. Closest related modules are `ingress` for Kubernetes ALB ingress annotations and `cloudwatch-alarm-notify` / `service-alerts` for alert patterns. There is no raw AWS NLB module.
+
+### Gaps Versus Internal Standards
+
+The target module does not exist yet. New files must include documented variables, outputs, examples/tests, version constraints, and generated or consistent README content.
+
+### Wrapper-Preservation Assessment
+
+The module will be an opinionated wrapper, not a broad pass-through. It exposes grouped objects for listeners, target groups, targets, and alarms. It intentionally does not expose DNS, certificate creation, notification endpoint creation, or every upstream ALB module input.
+
+### Provider Collection Checked
+
+Checked approved AWS module collection: `terraform-aws-modules`.
+
+### Candidate Upstream Modules Considered
+
+- `terraform-aws-modules/alb/aws`: supports Application and Network Load Balancers, listeners, target groups, target attachments, and security groups.
+- Direct AWS resources: rejected because a suitable upstream module exists.
+
+### Chosen Wrapper Baseline
+
+Use `terraform-aws-modules/alb/aws` with `load_balancer_type = "network"` and a narrower DasMeta interface. The wrapper adds CIDR allowlist defaults and target-health CloudWatch alarms.
+
+### Constitution Repository Source Used
+
+Used `/Users/Adeline/.codex/constitution/skills/terraform-module-developer/references/internal-module-standards.md` and planning checklist.
+
+### Speckit Evidence
+
+Manual evidence package: `specs/001-nlb-module/` with `spec.md`, `plan.md`, and `tasks.md`. Repo lacks `.specify/`, so this is recorded as a bounded workflow gap.
+
+### Module-Change Gate Compatibility
+
+Expected to satisfy a review-visible Speckit evidence requirement by including the local package. If a strict gate requires `.specify/feature.json`, this repo needs a separate Spec Kit bootstrap.
+
+### Fallback Rationale
+
+No fallback direct-resource scaffolding is needed because `terraform-aws-modules/alb/aws` is suitable.
+
+### Proposed File Changes
+
+- Add `modules/nlb/main.tf`.
+- Add `modules/nlb/variables.tf`.
+- Add `modules/nlb/outputs.tf`.
+- Add `modules/nlb/versions.tf`.
+- Add `modules/nlb/README.md`.
+- Add `modules/nlb/tests/basic/*`.
+- Add `modules/nlb` to workflow matrices that enumerate module paths.
+- Add `specs/001-nlb-module/*` evidence files.
+
+### Potential Breaking Changes
+
+None. The module is additive.
+
+### Potential Interface-Widening Changes
+
+None requiring approval. The interface is intentionally narrower than the upstream module.
+
+### Conflicts Requiring Approval
+
+No standards conflict found. The only workflow gap is missing `.specify/` bootstrap in the repository.
+
+## Modern Capabilities Check
+
+- **NLB creation**: supported by AWS provider and upstream module.
+- **NLB security groups**: supported. AWS documents creation-time association constraints for NLB security groups.
+- **Target health alarms**: supported through CloudWatch `AWS/NetworkELB` metrics.
+
+## Phase 0 Research
+
+See [research.md](research.md).
+
+## Phase 1 Design
+
+See [data-model.md](data-model.md), [contracts/module-interface.md](contracts/module-interface.md), and [quickstart.md](quickstart.md).
+
+## Post-Design Constitution Check
+
+- **Scope Gate**: PASS.
+- **Ownership Gate**: PASS.
+- **Records Gate**: PASS WITH EXCEPTION for missing `.specify/`.
+- **Controls Gate**: PASS.
+- **Change Gate**: PASS.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| Manual Speckit package | Repo lacks `.specify/` | Editing module files with no evidence would violate the module workflow |

--- a/specs/001-nlb-module/quickstart.md
+++ b/specs/001-nlb-module/quickstart.md
@@ -1,0 +1,21 @@
+# Quickstart: Generic AWS NLB Module
+
+## Validate The Module
+
+```bash
+terraform -chdir=modules/nlb init -backend=false
+terraform -chdir=modules/nlb validate
+```
+
+## Validate The Basic Example
+
+```bash
+terraform -chdir=modules/nlb/tests/basic init -backend=false
+terraform -chdir=modules/nlb/tests/basic validate
+```
+
+## Format Check
+
+```bash
+terraform fmt -check modules/nlb specs/001-nlb-module
+```

--- a/specs/001-nlb-module/research.md
+++ b/specs/001-nlb-module/research.md
@@ -1,0 +1,36 @@
+# Research: Generic AWS NLB Module
+
+## Decision: Wrap `terraform-aws-modules/alb/aws`
+
+**Rationale**: The approved AWS module collection already has a maintained module that creates Network Load Balancers, listeners, target groups, target attachments, and security groups. A DasMeta wrapper can keep the consumer interface smaller and add target-health alarms.
+
+**Alternatives considered**:
+
+- Direct AWS resources: rejected because it would recreate an existing upstream module surface.
+- Kubernetes ingress module: rejected because it is ALB ingress-controller-specific and does not create a raw AWS NLB.
+
+## Decision: Require AWS Provider >= 5.99
+
+**Rationale**: The selected upstream module version requires AWS provider >= 5.99, and this remains compatible with consumers using the AWS provider 5.x range.
+
+**Alternatives considered**:
+
+- Older upstream module versions: rejected because current NLB security group support is a core requirement.
+- Latest upstream main: rejected because it requires AWS provider 6.x and Terraform >= 1.5.7.
+
+## Decision: Create Target-Health Alarms In The Wrapper
+
+**Rationale**: Target health is part of the requested NLB operational behavior. CloudWatch publishes `AWS/NetworkELB` metrics with `LoadBalancer` and `TargetGroup` dimensions. Creating one alarm per target group keeps behavior predictable.
+
+**Alternatives considered**:
+
+- Use `cloudwatch-alarm-notify`: rejected for this module because notification endpoint creation would broaden the interface.
+- Leave alarms to consumers: rejected because the user specifically requested related alerts.
+
+## Decision: Keep Notification Actions Consumer-Owned
+
+**Rationale**: SNS topics, Opsgenie, Slack, and email endpoints are environment-owned. The NLB module should accept CloudWatch action ARNs without owning notification plumbing.
+
+**Alternatives considered**:
+
+- Create SNS topics inside the module: rejected because it would mix load-balancing and notification ownership.

--- a/specs/001-nlb-module/spec.md
+++ b/specs/001-nlb-module/spec.md
@@ -1,0 +1,103 @@
+# Feature Specification: Generic AWS NLB Module
+
+**Feature Branch**: `main`
+**Created**: 2026-07-27
+**Status**: Draft
+**Input**: Create a reusable Terraform module under `modules/nlb` that creates an AWS Network Load Balancer, supports security group allowlisting, supports generic target attachment, and adds alerts when targets have health problems.
+
+## Operational Scope & Boundaries
+
+**In Scope**: A reusable AWS Network Load Balancer module in `modules/nlb`, including listener and target group creation, optional target attachment, creation-time security group association with CIDR allowlists, useful outputs, README/example coverage, and CloudWatch target-health alarms.
+
+**Out of Scope**: Environment-specific database wiring, staging-specific names, generated downstream Terraform consumer changes, DNS records, TLS certificate provisioning, and notification endpoint creation.
+
+**Impacted Functions**: Platform engineers and service operators that need reusable TCP/TLS/UDP load balancing.
+
+**Accountable Owner**: DasMeta infrastructure module maintainer.
+
+**Required Approvers**: DasMeta infrastructure module reviewer.
+
+**Downstream Consumers**: Terraform roots that currently consume `dasmeta/modules/aws//modules/...`.
+
+## User Scenarios & Testing
+
+### User Story 1 - Create A Reusable NLB (Priority: P1)
+
+As a platform engineer, I need a reusable module that creates a Network Load Balancer with listeners and target groups so service roots can expose TCP-style targets without writing raw AWS load balancer resources each time.
+
+**Independent Test**: `terraform validate` succeeds for `modules/nlb/tests/basic`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a module consumer provides a name, VPC, subnets, listener, and target group, **When** Terraform is validated, **Then** the module exposes a valid NLB configuration.
+2. **Given** a target group defines target attachments, **When** Terraform is validated, **Then** those targets are connected to the matching target group.
+
+### User Story 2 - Restrict NLB Access By CIDR (Priority: P1)
+
+As a platform engineer, I need the module to create or attach security groups at NLB creation time so consumers can allow traffic only from explicit CIDR ranges such as a single `/32`.
+
+**Independent Test**: The basic test includes an explicit `/32` allowlist and validates module inputs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer provides allowed CIDR blocks, **When** Terraform is validated, **Then** the module creates listener-port security group ingress rules for those CIDRs.
+2. **Given** a consumer does not want the module-managed security group, **When** they pass existing security group IDs or disable creation, **Then** the module supports that explicit choice.
+
+### User Story 3 - Alert On Target Health Problems (Priority: P2)
+
+As a service operator, I need target-health alarms for each target group so target failures are visible through existing CloudWatch alarm actions.
+
+**Independent Test**: The basic test enables alarms and passes an SNS action ARN.
+
+**Acceptance Scenarios**:
+
+1. **Given** alarms are enabled, **When** Terraform is validated, **Then** the module defines one target-health alarm per target group.
+2. **Given** a target group reports unhealthy targets, **When** CloudWatch evaluates the alarm, **Then** configured alarm actions receive the alert.
+
+## Requirements
+
+- **FR-001**: The module MUST live at `modules/nlb`.
+- **FR-002**: The module MUST create an AWS Network Load Balancer through an opinionated wrapper interface.
+- **FR-003**: The module MUST support internal and internet-facing NLBs.
+- **FR-004**: The module MUST support listener definitions for TCP, TLS, UDP, and TCP_UDP.
+- **FR-005**: The module MUST support target groups with IP, instance, or ALB targets.
+- **FR-006**: The module MUST support target attachments keyed by target group.
+- **FR-007**: The module MUST support module-managed security group creation with IPv4 CIDR allowlists.
+- **FR-008**: The module MUST support existing security group IDs when consumers manage security groups externally.
+- **FR-009**: The module MUST document that NLB security groups should be associated at creation time when allowlisting is required.
+- **FR-010**: The module MUST create CloudWatch target-health alarms per target group when alarms are enabled.
+- **FR-011**: Alarm actions MUST be supplied by consumers; the module MUST NOT create notification endpoints.
+- **FR-012**: The module MUST expose load balancer, listener, target group, security group, and alarm outputs useful to downstream roots.
+- **FR-013**: The module MUST include at least one executable Terraform example test.
+- **FR-014**: The module MUST be added to repository workflow matrices that enumerate module paths.
+
+## Key Entities
+
+- **NLB Module Configuration**: Module-level name, VPC, subnets, scheme, tags, security group behavior, listeners, target groups, and alarms.
+- **Listener**: Port/protocol entry that forwards to a target group.
+- **Target Group**: Backend routing and health-check configuration.
+- **Target Attachment**: Target ID plus optional target port and availability zone.
+- **Target Health Alarm**: CloudWatch alarm watching `AWS/NetworkELB` target health dimensions.
+
+## Success Criteria
+
+- **SC-001**: `terraform validate` succeeds for `modules/nlb`.
+- **SC-002**: `terraform validate` succeeds for `modules/nlb/tests/basic`.
+- **SC-003**: The module exposes a generic interface with no environment-specific or staging-specific naming.
+- **SC-004**: The README documents the one-IP allowlist use case and target-health alarm behavior.
+
+## Assumptions
+
+- Consumers can provide SNS topic ARNs or other CloudWatch alarm action ARNs.
+- A wrapper around `terraform-aws-modules/alb/aws` is acceptable because that upstream module supports Network Load Balancer resources.
+- Terraform optional object attributes are acceptable in this repository for new module code.
+
+## Risks & Exceptions
+
+- **Risk**: An NLB created without security groups cannot have security groups added later without replacement.
+  **Mitigation**: Document this constraint and make security group behavior explicit.
+
+- **Risk**: Broad pass-through inputs would make the wrapper hard to support.
+  **Mitigation**: Expose only common NLB inputs and rely on the upstream module for low-level implementation details.
+
+- **Exception**: The repository currently lacks `.specify/`; this package records the module-change evidence manually under `specs/001-nlb-module`.

--- a/specs/001-nlb-module/tasks.md
+++ b/specs/001-nlb-module/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Generic AWS NLB Module
+
+**Input**: Design documents from `specs/001-nlb-module/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/module-interface.md`
+
+## Phase 1: Setup
+
+- [x] T001 Create manual Speckit evidence package in `specs/001-nlb-module/`
+- [x] T002 Create `modules/nlb/tests/basic` Terraform example test before production module code
+
+## Phase 2: User Story 1 - Create A Reusable NLB
+
+- [x] T003 [US1] Run red `terraform -chdir=modules/nlb/tests/basic init -backend=false` and `terraform -chdir=modules/nlb/tests/basic validate`
+- [x] T004 [US1] Implement NLB wrapper resources in `modules/nlb/main.tf`
+- [x] T005 [US1] Implement module input contract in `modules/nlb/variables.tf`
+- [x] T006 [US1] Implement module outputs in `modules/nlb/outputs.tf`
+- [x] T007 [US1] Implement provider constraints in `modules/nlb/versions.tf`
+
+## Phase 3: User Story 2 - Restrict NLB Access By CIDR
+
+- [x] T008 [US2] Add listener-port security group ingress rule derivation in `modules/nlb/main.tf`
+- [x] T009 [US2] Document NLB security group creation-time behavior in `modules/nlb/README.md`
+
+## Phase 4: User Story 3 - Alert On Target Health Problems
+
+- [x] T010 [US3] Add per-target-group `AWS/NetworkELB` unhealthy-target alarms in `modules/nlb/main.tf`
+- [x] T011 [US3] Add alarm outputs in `modules/nlb/outputs.tf`
+- [x] T012 [US3] Document alarm inputs and behavior in `modules/nlb/README.md`
+
+## Phase 5: CI And Verification
+
+- [x] T013 Add `modules/nlb` to workflow matrices in `.github/workflows/`
+- [x] T014 Run `terraform fmt -check modules/nlb`
+- [x] T015 Run `terraform -chdir=modules/nlb init -backend=false`
+- [x] T016 Run `terraform -chdir=modules/nlb validate`
+- [x] T017 Run `terraform -chdir=modules/nlb/tests/basic init -backend=false`
+- [x] T018 Run `terraform -chdir=modules/nlb/tests/basic validate`
+
+## Dependencies
+
+T001 before all implementation. T002 and T003 before production module code. T004-T008 before T010-T012. Verification runs after implementation and docs.
+
+## Independent Test Criteria
+
+- **US1**: Basic example validates with one listener and one target group.
+- **US2**: Basic example validates with a single `/32` CIDR allowlist.
+- **US3**: Basic example validates with target-health alarms enabled and alarm actions supplied.


### PR DESCRIPTION
## Summary
- Add reusable `modules/nlb` wrapper around `terraform-aws-modules/alb/aws` for AWS Network Load Balancers.
- Add CIDR-based NLB security group allowlisting, generic target attachments, useful outputs, and per-target-group `UnHealthyHostCount` CloudWatch alarms.
- Add a basic validation fixture, Speckit evidence, and CI matrix entries for the new module.

## Test Plan
- `terraform fmt -check -recursive modules/nlb`
- `terraform -chdir=modules/nlb validate`
- `terraform -chdir=modules/nlb/tests/basic validate`

## Notes
- Local `git push` was unavailable because this checkout has no GitHub credentials; the branch was published through the connected GitHub API.
